### PR TITLE
os/darwin: switch from using ResetDevice to USBDeviceReEnumerate

### DIFF
--- a/libusb/os/darwin_usb.c
+++ b/libusb/os/darwin_usb.c
@@ -1,7 +1,7 @@
 /* -*- Mode: C; indent-tabs-mode:nil -*- */
 /*
  * darwin backend for libusb 1.0
- * Copyright © 2008-2014 Nathan Hjelm <hjelmn@users.sourceforge.net>
+ * Copyright © 2008-2018 Nathan Hjelm <hjelmn@users.sourceforge.net>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -595,7 +595,7 @@ static int darwin_check_configuration (struct libusb_context *ctx, struct darwin
   } else
     /* not configured */
     dev->active_config = 0;
-  
+
   usbi_dbg ("active config: %u, first config: %u", dev->active_config, dev->first_config);
 
   return 0;
@@ -1339,9 +1339,10 @@ static int darwin_reset_device(struct libusb_device_handle *dev_handle) {
   IOReturn kresult;
   int i;
 
-  kresult = (*(dpriv->device))->ResetDevice (dpriv->device);
+  /* from macOS 10.11 ResetDevice no longer does anything so just use USBDeviceReEnumerate */
+  kresult = (*(dpriv->device))->USBDeviceReEnumerate (dpriv->device, 0);
   if (kresult) {
-    usbi_err (HANDLE_CTX (dev_handle), "ResetDevice: %s", darwin_error_str (kresult));
+    usbi_err (HANDLE_CTX (dev_handle), "USBDeviceReEnumerate: %s", darwin_error_str (kresult));
     return darwin_to_libusb (kresult);
   }
 


### PR DESCRIPTION
While `USBDeviceReEnumerate` is not an exact replacement of `ResetDevice` on macOS, it provides what is needed for devices that require a "soft reset", and is less confusing than the current implementation that just fails silently.

This has recently been fixed in upstream libusb, so I have just cherry-picked the change. See discussions here:

- https://github.com/tessel/node-usb/issues/159
- https://github.com/libusb/libusb/issues/455

