### PR TITLE
[Backport] Windows: Restrict path for dynamic library loading

### DIFF
--- a/libusb/Makefile.am
+++ b/libusb/Makefile.am
@@ -15,7 +15,7 @@ WINCE_USB_SRC = os/wince_usb.c os/wince_usb.h
 EXTRA_DIST = $(LINUX_USBFS_SRC) $(DARWIN_USB_SRC) $(OPENBSD_USB_SRC) \
 	$(NETBSD_USB_SRC) $(WINDOWS_USB_SRC) $(WINCE_USB_SRC) \
 	$(POSIX_POLL_SRC) \
-	os/threads_posix.c os/threads_windows.c \
+	os/threads_posix.c os/threads_windows.c os/windows_common.c \
 	os/linux_udev.c os/linux_netlink.c
 
 if OS_LINUX

--- a/libusb/os/windows_common.c
+++ b/libusb/os/windows_common.c
@@ -1,0 +1,59 @@
+/*
+ * windows backend for libusb 1.0
+ * Copyright © 2009-2012 Pete Batard <pete@akeo.ie>
+ * With contributions from Michael Plante, Orin Eman et al.
+ * Parts of this code adapted from libusb-win32-v1 by Stephan Meyer
+ * HID Reports IOCTLs inspired from HIDAPI by Alan Ott, Signal 11 Software
+ * Hash table functions adapted from glibc, by Ulrich Drepper et al.
+ * Major code testing contribution by Xiaofan Chen
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include <config.h>
+
+#include <stdio.h>
+
+#include "libusbi.h"
+#include "windows_common.h"
+
+/*
+ * Dynamically loads a DLL from the Windows system directory.  Unlike the
+ * LoadLibraryA() function, this function will not search through any
+ * directories to try and find the library.
+ */
+HMODULE load_system_library(struct libusb_context *ctx, const char *name)
+{
+	char library_path[MAX_PATH];
+	char *filename_start;
+	UINT length;
+
+	length = GetSystemDirectoryA(library_path, sizeof(library_path));
+	if ((length == 0) || (length >= (UINT)sizeof(library_path))) {
+		usbi_err(ctx, "program assertion failed - could not get system directory");
+		return NULL;
+	}
+
+	filename_start = library_path + length;
+	// Append '\' + name + ".dll" + NUL
+	length += 1 + strlen(name) + 4 + 1;
+	if (length >= (UINT)sizeof(library_path)) {
+		usbi_err(ctx, "program assertion failed - library path buffer overflow");
+		return NULL;
+	}
+
+	sprintf(filename_start, "\\%s.dll", name);
+	return LoadLibraryA(library_path);
+}

--- a/libusb/os/windows_common.h
+++ b/libusb/os/windows_common.h
@@ -73,36 +73,36 @@
 #ifndef _WIN32_WCE
 #define DLL_STRINGIFY(dll) #dll
 #define DLL_GET_MODULE_HANDLE(dll) GetModuleHandleA(DLL_STRINGIFY(dll))
-#define DLL_LOAD_LIBRARY(dll) LoadLibraryA(DLL_STRINGIFY(dll))
 #else
 #define DLL_STRINGIFY(dll) L#dll
 #define DLL_GET_MODULE_HANDLE(dll) GetModuleHandle(DLL_STRINGIFY(dll))
-#define DLL_LOAD_LIBRARY(dll) LoadLibrary(DLL_STRINGIFY(dll))
 #endif
 
-#define DLL_LOAD_PREFIXNAME(dll, prefixname, name, ret_on_failure) \
-	do {                                                           \
-		HMODULE h = DLL_GET_MODULE_HANDLE(dll);                    \
-	if (!h)                                                        \
-		h = DLL_LOAD_LIBRARY(dll);                                 \
-	if (!h) {                                                      \
-		if (ret_on_failure) { return LIBUSB_ERROR_NOT_FOUND; }     \
-		else { break; }                                            \
-	}                                                              \
-	prefixname = (__dll_##name##_t)GetProcAddress(h,               \
-	                        DLL_STRINGIFY(name));                  \
-	if (prefixname) break;                                         \
-	prefixname = (__dll_##name##_t)GetProcAddress(h,               \
-	                        DLL_STRINGIFY(name) DLL_STRINGIFY(A)); \
-	if (prefixname) break;                                         \
-	prefixname = (__dll_##name##_t)GetProcAddress(h,               \
-	                        DLL_STRINGIFY(name) DLL_STRINGIFY(W)); \
-	if (prefixname) break;                                         \
-	if(ret_on_failure)                                             \
-		return LIBUSB_ERROR_NOT_FOUND;                             \
+#define DLL_LOAD_PREFIXNAME(ctx, dll, prefixname, name, ret_on_failure) \
+	do {                                                                \
+		HMODULE h = DLL_GET_MODULE_HANDLE(dll);                         \
+	if (!h)                                                             \
+		h = load_system_library(ctx, DLL_STRINGIFY(dll));               \
+	if (!h) {                                                           \
+		if (ret_on_failure) { return LIBUSB_ERROR_NOT_FOUND; }          \
+		else { break; }                                                 \
+	}                                                                   \
+	prefixname = (__dll_##name##_t)GetProcAddress(h,                    \
+	                        DLL_STRINGIFY(name));                       \
+	if (prefixname) break;                                              \
+	prefixname = (__dll_##name##_t)GetProcAddress(h,                    \
+	                        DLL_STRINGIFY(name) DLL_STRINGIFY(A));      \
+	if (prefixname) break;                                              \
+	prefixname = (__dll_##name##_t)GetProcAddress(h,                    \
+	                        DLL_STRINGIFY(name) DLL_STRINGIFY(W));      \
+	if (prefixname) break;                                              \
+	if(ret_on_failure)                                                  \
+		return LIBUSB_ERROR_NOT_FOUND;                                  \
 	} while(0)
 
 #define DLL_DECLARE(api, ret, name, args)   DLL_DECLARE_PREFIXNAME(api, ret, name, name, args)
-#define DLL_LOAD(dll, name, ret_on_failure) DLL_LOAD_PREFIXNAME(dll, name, name, ret_on_failure)
+#define DLL_LOAD(ctx, dll, name, ret_on_failure) DLL_LOAD_PREFIXNAME(ctx, dll, name, name, ret_on_failure)
 #define DLL_DECLARE_PREFIXED(api, ret, prefix, name, args)   DLL_DECLARE_PREFIXNAME(api, ret, prefix##name, name, args)
-#define DLL_LOAD_PREFIXED(dll, prefix, name, ret_on_failure) DLL_LOAD_PREFIXNAME(dll, prefix##name, name, ret_on_failure)
+#define DLL_LOAD_PREFIXED(ctx, dll, prefix, name, ret_on_failure) DLL_LOAD_PREFIXNAME(ctx, dll, prefix##name, name, ret_on_failure)
+
+HMODULE load_system_library(struct libusb_context *ctx, const char *name);

--- a/msvc/libusb_dll.dsp
+++ b/msvc/libusb_dll.dsp
@@ -135,6 +135,10 @@ SOURCE=..\libusb\os\threads_windows.c
 # End Source File
 # Begin Source File
 
+SOURCE=..\libusb\os\windows_common.c
+# End Source File
+# Begin Source File
+
 SOURCE=..\libusb\os\windows_usb.c
 # End Source File
 # End Group

--- a/msvc/libusb_dll_2005.vcproj
+++ b/msvc/libusb_dll_2005.vcproj
@@ -374,6 +374,10 @@
 				>
 			</File>
 			<File
+				RelativePath="..\libusb\os\windows_common.c"
+				>
+			</File>
+			<File
 				RelativePath="..\libusb\os\windows_usb.c"
 				>
 			</File>

--- a/msvc/libusb_dll_2010.vcxproj
+++ b/msvc/libusb_dll_2010.vcxproj
@@ -146,6 +146,7 @@
     <ClCompile Include="..\libusb\strerror.c" />
     <ClCompile Include="..\libusb\sync.c" />
     <ClCompile Include="..\libusb\os\threads_windows.c" />
+    <ClInclude Include="..\libusb\os\windows_common.c" />
     <ClCompile Include="..\libusb\os\windows_usb.c" />
   </ItemGroup>
   <ItemGroup>

--- a/msvc/libusb_dll_2010.vcxproj.filters
+++ b/msvc/libusb_dll_2010.vcxproj.filters
@@ -38,6 +38,9 @@
     <ClCompile Include="..\libusb\os\threads_windows.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\libusb\os\windows_common.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\libusb\os\windows_usb.c">
       <Filter>Source Files</Filter>
     </ClCompile>

--- a/msvc/libusb_dll_2012.vcxproj
+++ b/msvc/libusb_dll_2012.vcxproj
@@ -150,6 +150,7 @@
     <ClCompile Include="..\libusb\strerror.c" />
     <ClCompile Include="..\libusb\sync.c" />
     <ClCompile Include="..\libusb\os\threads_windows.c" />
+    <ClCompile Include="..\libusb\os\windows_common.c" />
     <ClCompile Include="..\libusb\os\windows_usb.c" />
   </ItemGroup>
   <ItemGroup>

--- a/msvc/libusb_dll_2012.vcxproj.filters
+++ b/msvc/libusb_dll_2012.vcxproj.filters
@@ -35,6 +35,9 @@
     <ClCompile Include="..\libusb\os\threads_windows.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\libusb\os\windows_common.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\libusb\os\windows_usb.c">
       <Filter>Source Files</Filter>
     </ClCompile>

--- a/msvc/libusb_dll_2013.vcxproj
+++ b/msvc/libusb_dll_2013.vcxproj
@@ -150,6 +150,7 @@
     <ClCompile Include="..\libusb\strerror.c" />
     <ClCompile Include="..\libusb\sync.c" />
     <ClCompile Include="..\libusb\os\threads_windows.c" />
+    <ClCompile Include="..\libusb\os\windows_common.c" />
     <ClCompile Include="..\libusb\os\windows_usb.c" />
   </ItemGroup>
   <ItemGroup>

--- a/msvc/libusb_sources
+++ b/msvc/libusb_sources
@@ -34,5 +34,6 @@ SOURCES=..\core.c \
 	..\hotplug.c \
 	threads_windows.c \
 	poll_windows.c \
+	windows_common.c \
 	windows_usb.c \
 	..\libusb-1.0.rc

--- a/msvc/libusb_static.dsp
+++ b/msvc/libusb_static.dsp
@@ -119,6 +119,10 @@ SOURCE=..\libusb\os\threads_windows.c
 # End Source File
 # Begin Source File
 
+SOURCE=..\libusb\os\windows_common.c
+# End Source File
+# Begin Source File
+
 SOURCE=..\libusb\os\windows_usb.c
 # End Source File
 # End Group

--- a/msvc/libusb_static_2005.vcproj
+++ b/msvc/libusb_static_2005.vcproj
@@ -314,6 +314,10 @@
 				>
 			</File>
 			<File
+				RelativePath="..\libusb\os\windows_common.c"
+				>
+			</File>
+			<File
 				RelativePath="..\libusb\os\windows_usb.c"
 				>
 			</File>

--- a/msvc/libusb_static_2010.vcxproj
+++ b/msvc/libusb_static_2010.vcxproj
@@ -136,6 +136,7 @@
     <ClCompile Include="..\libusb\strerror.c" />
     <ClCompile Include="..\libusb\sync.c" />
     <ClCompile Include="..\libusb\os\threads_windows.c" />
+    <ClCompile Include="..\libusb\os\windows_common.c" />
     <ClCompile Include="..\libusb\os\windows_usb.c" />
   </ItemGroup>
   <ItemGroup>

--- a/msvc/libusb_static_2010.vcxproj.filters
+++ b/msvc/libusb_static_2010.vcxproj.filters
@@ -32,6 +32,9 @@
     <ClCompile Include="..\libusb\os\threads_windows.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\libusb\os\windows_common.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\libusb\os\windows_usb.c">
       <Filter>Source Files</Filter>
     </ClCompile>

--- a/msvc/libusb_static_2012.vcxproj
+++ b/msvc/libusb_static_2012.vcxproj
@@ -140,6 +140,7 @@
     <ClCompile Include="..\libusb\strerror.c" />
     <ClCompile Include="..\libusb\sync.c" />
     <ClCompile Include="..\libusb\os\threads_windows.c" />
+    <ClCompile Include="..\libusb\os\windows_common.c" />
     <ClCompile Include="..\libusb\os\windows_usb.c" />
   </ItemGroup>
   <ItemGroup>

--- a/msvc/libusb_static_2012.vcxproj.filters
+++ b/msvc/libusb_static_2012.vcxproj.filters
@@ -32,6 +32,9 @@
     <ClCompile Include="..\libusb\os\threads_windows.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\libusb\os\windows_common.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\libusb\os\windows_usb.c">
       <Filter>Source Files</Filter>
     </ClCompile>

--- a/msvc/libusb_static_2013.vcxproj
+++ b/msvc/libusb_static_2013.vcxproj
@@ -140,6 +140,7 @@
     <ClCompile Include="..\libusb\strerror.c" />
     <ClCompile Include="..\libusb\sync.c" />
     <ClCompile Include="..\libusb\os\threads_windows.c" />
+    <ClCompile Include="..\libusb\os\windows_common.c" />
     <ClCompile Include="..\libusb\os\windows_usb.c" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
This PR prevents DLL planting on Windows.

libusb loads USB backends from various path using `LoadLibrary`. This
function performs a search through various path when provided a library
name that does not include a path element. An attacker could plant a DLL
in one of the searched path, and it would be loaded by libusb.

To prevent this, libraries are now only loaded from the Windows system
directory.

Based on <https://github.com/libusb/libusb/commit/c3deb6dd6440fd467ce12965742f2d7a228b3bbe>